### PR TITLE
fix the cpp bug

### DIFF
--- a/utilities/compute_zscore.cpp
+++ b/utilities/compute_zscore.cpp
@@ -27,18 +27,21 @@ void write_file(NumericMatrix num,std::string output_file_name)
     CharacterVector row_names = rownames(num);
 
     myfile <<"Hugo_Symbol"<<"\t";
-    for(auto p = column_names.begin(); p != column_names.end(); ++p){
+    for(auto p = column_names.begin(); p != column_names.end()-1; ++p){
           myfile << *p<<"\t";
       }
+      myfile << *(column_names.end()-1); //do not add tab at the end of row
     myfile <<"\n";
+    
     for(size_t i = 0; i < num.nrow();++i){
         myfile << row_names(i)<<"\t";
-        for(size_t j = 0; j <  num.ncol();++j ){
+        for(size_t j = 0; j < num.ncol()-1;++j ){
             myfile << num(i,j)<<"\t";
           }
-        myfile <<"\n";
+          myfile << num(i,num.ncol()-1); //do not add tab at the end of row
+        myfile <<"\n"; //change of line
       }
-    myfile.close();
+    myfile.close();  // close the file
 }
 
 /**


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

This PR fixes the C++ bug to remove the last tab (\t) entry from the output file

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A: Tested locally and it work as desired 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have committed any related changes to the PR
