### PR TITLE
🔧 Fixed CNV bug discovered while running ETL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ The steps in `cbio-etl import` are outlined as follows:
 ## Local Installation
 ### Software Prerequisites
 + `python3` v3.10+
-+ [`bedtools`](https://bedtools.readthedocs.io/en/latest/content/installation.html)
-+ `Try::Tiny` Perl module
 + [`saml2aws`](https://github.com/Versent/saml2aws) - [directions to use](https://www.notion.so/d3b/Setup-SAML-Login-1056131f1200806ba182f7b7c1793a40?pvs=4)
 + Access to [AWS Infra PedCBioPortal Import](https://github.com/d3b-center/aws-infra-pedcbioportal-import) repo for server loading
 + Access to the `postgres` D3b Warehouse database at `d3b-warehouse-aurora-prd.d3b.io`. Need at least read access to tables with the `bix_workflows` schema
@@ -64,22 +62,32 @@ cbio-etl import \
 ## Docker Installation
 ### Installation Steps
 ```sh
-docker pull pgc-images.sbgenomics.com/d3b-bixu/cbio-etl:v2.2.0
+docker pull pgc-images.sbgenomics.com/d3b-bixu/cbio-etl:cbio-etl-runtime-env
 ```
 
 ### Usage
 ```
+# Start container interactively
 docker run --rm -it \
     -v /path/to/db.ini:/credentials/db.ini \
     -v /path/to/cbioportal_data_access_token.txt:/credentials/cbioportal_data_access_token.txt \
     -v /path/to/.sevenbridges/credentials:/root/.sevenbridges/credentials \
     -v /path/to/output_dir:/output \
-    cbio-etl /bin/bash -c "cd /output && cbio-etl update \
+    cbio-etl-runtime-env /bin/bash
+    
+# Install cbio-etl within container
+cd kf-cbioportal-etl/
+# git checkout v2.3.1  # Use a specific version instead of the latest from main
+pip install .
+
+# Run cbio-etl
+cd /output/
+cbio-etl update \
     --db-ini /credentials/db.ini \
     --token /credentials/cbioportal_data_access_token.txt \
     --study pbta_pnoc \
     --sbg-profile default \
-    --dgd-status kf"
+    --dgd-status kf
 ```
 
 ## Collaborative and Publication Workflows

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cbio-etl",
-    version="2.2.0",
+    version="2.3.1",
     author="Jessica Wong & Miguel Brown",
     description="A tool/ETL for converting data from CAVATICA and Data Warehouse to PedcBioportal format",
     packages=find_packages(),


### PR DESCRIPTION
:pencil: updated docs and version

<!--Pull Request Template-->

## Description

While working on updating chordoma studies, validation failed. CNV values in the GISTIC style outputs were exceeding the -2:2 bounds. I hypothesize that `as_completed()` may not necessarily mean it will keep iterating through the futures task list until it's all done, at least no in ProcessPool mode. Using `wait()` instead for all to be finished seems more reliable.

Also bumped version of ETL

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [c] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Validation passed after bug fix
- [ ] Test B

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
